### PR TITLE
Release v1.0.0 💎

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-tasks (0.6.0)
+    jekyll-tasks (1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/jekyll/tasks/menus.rb
+++ b/lib/jekyll/tasks/menus.rb
@@ -56,7 +56,7 @@ module Jekyll
 
         files = markdown_files collection
         files.each do |file|
-          data = YAML.load_file(file)
+          data = YAML.load_file(file, permitted_classes: [Date])
           conflicts << analyze_conflicts_without_properties(data)
         end
 
@@ -66,7 +66,7 @@ module Jekyll
       def search_properties(collection, properties, result = [])
         files = markdown_files collection
         files.each do |file|
-          data = YAML.load_file(file)
+          data = YAML.load_file(file, permitted_classes: [Date])
           properties.each do |property|
             search_property result, data, property
           end

--- a/lib/jekyll/tasks/products.rb
+++ b/lib/jekyll/tasks/products.rb
@@ -23,7 +23,7 @@ module Jekyll
       def model_list
         products = []
         path_list.each do |product|
-          data = YAML.load_file(product)
+          data = YAML.load_file(product, permitted_classes: [Date])
           products << data['title']
         end
         products
@@ -34,7 +34,7 @@ module Jekyll
       end
 
       def title(product)
-        data = YAML.load_file("#{PRODUCTS_PATH}#{product}#{EXTENSION}")
+        data = YAML.load_file("#{PRODUCTS_PATH}#{product}#{EXTENSION}", permitted_classes: [Date])
         data['title']
       end
 

--- a/lib/jekyll/tasks/version.rb
+++ b/lib/jekyll/tasks/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Tasks
-    VERSION = '0.6.0'
+    VERSION = '1.0.0'
   end
 end


### PR DESCRIPTION
Allow Date data types in YAML serialization

Backtrace:
```
Psych::DisallowedClass: Tried to load unspecified class: Date
```

Ref: https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017